### PR TITLE
Option to allow forwarded ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If you are interested, [check out](https://hub.docker.com/r/crazymax/) my other 
 * `FF_SYNCSERVER_ALLOW_NEW_USERS` : Set this to `false` to disable new-user signups on the server. Only request by existing accounts will be honoured (default `true`).
 * `FF_SYNCSERVER_FORCE_WSGI_ENVIRON` : Set this to `true` to work around a mismatch between public_url and the application URL as seen by python, which can happen in certain reverse-proxy hosting setups (default `false`).
 * `FF_SYNCSERVER_SQLURI` : Defines the database in which to store all server data (default `sqlite:///data/syncserver.db`).
+* `FF_SYNCSERVER_FORWARDED_ALLOW_IPS` : Set this to `*` or an IP range if you use an Nginx reverse proxy (optional). 
 
 ### Volumes
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,9 +18,11 @@ if [ -z "$FF_SYNCSERVER_SECRET" ] ; then
   exit 1
 fi
 
+SYNCSERVER_INI_PATH="/syncserver.ini"
+
 # Config
 echo "Generating configuration..."
-cat > "/syncserver.ini" <<EOL
+cat > "$SYNCSERVER_INI_PATH" <<EOL
 [server:main]
 use = egg:gunicorn
 host = 0.0.0.0
@@ -66,6 +68,14 @@ force_wsgi_environ = ${FF_SYNCSERVER_FORCE_WSGI_ENVIRON}
 #[browserid]
 #backend = tokenserver.verifiers.LocalVerifier
 #audiences = https://localhost:5000
+
 EOL
+
+if [ -n "$FF_SYNCSERVER_FORWARDED_ALLOW_IPS" ]; then
+  cat >> "$SYNCSERVER_INI_PATH" <<EOL
+# If you are running Nginx on a different host than the ff sync server the ff snyc server have to trust the X-Forwarded-* headers sent by Nginx.
+forwarded_allow_ips = ${FF_SYNCSERVER_FORWARDED_ALLOW_IPS}
+EOL
+fi
 
 exec "$@"


### PR DESCRIPTION
Hi crazy-max,

I tried the container last night and missed the option to set `forwarded_allow_ips = *` env variable.
The variable is necessary for me because I am using the container behind a nginx reverse proxy.

The need for this option is here documented:
https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html
And also in the gunicorn docs:
https://github.com/benoitc/gunicorn/blob/9cf5b13f93a3ac712cbabb3b41e34eb6ec9d5eb6/docs/source/deploy.rst#nginx-configuration

What do you think about my commit?